### PR TITLE
Revert "Update bleachbit.git to 4.5.0"

### DIFF
--- a/org.bleachbit.BleachBit.yml
+++ b/org.bleachbit.BleachBit.yml
@@ -33,7 +33,7 @@ modules:
           type: json
           url: https://api.github.com/repos/bleachbit/bleachbit/releases/latest
           version-query: .tag_name
-          url-query: .tarball_url
+          tag-query: .tag_name
           timestamp-query: .published_at
       - type: shell
         commands:


### PR DESCRIPTION
This reverts commit 3810973f0262f74f47bf70730ccf32904e45792c and avoids automatically updating to pre-release versions again