### PR TITLE
Grant access to /tmp and /var/tmp

### DIFF
--- a/org.bleachbit.BleachBit.yml
+++ b/org.bleachbit.BleachBit.yml
@@ -10,6 +10,8 @@ finish-args:
   - --socket=wayland
   - --filesystem=home
   - --filesystem=~/.var/app
+  - --filesystem=/tmp
+  - --filesystem=/var/tmp
   # update cleaner rules
   - --share=network
   - --own-name=org.gnome.Bleachbit


### PR DESCRIPTION
If these aren't explicitly declared, any attempts to access those directories get routed to the Flatpak app's cache instead of the system tmp folders. The problem with this is that BleachBit is intended to clear system-wide temporary files instead of just its own temporary files.